### PR TITLE
Updates for Ruby 2.3.3

### DIFF
--- a/mohawk.gemspec
+++ b/mohawk.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'childprocess', '~> 0.5'
 
   gem.add_development_dependency 'cucumber'
-  gem.add_development_dependency 'rspec', '2.14.1'
+  gem.add_development_dependency 'rspec', '3.5.0'
   gem.add_development_dependency 'rspec-given'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'childprocess'
@@ -32,5 +32,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'guard'
   gem.add_development_dependency 'guard-rspec'
   gem.add_development_dependency 'terminal-notifier-guard'
-  gem.add_development_dependency 'json', '~> 1.7.7'
+  gem.add_development_dependency 'json', '~> 2.1.0'
 end

--- a/spec/lib/mohawk/adapters/uia/control_spec.rb
+++ b/spec/lib/mohawk/adapters/uia/control_spec.rb
@@ -29,7 +29,7 @@ describe Mohawk::Adapters::UiaAdapter::Control do
   end
 
   context '#patterns' do
-    Given { parent.stub(:find) {|l| @locator = l } }
+    Given { allow(parent).to receive(:find) {|l| @locator = l } }
     Given(:no_filter) { new_control(id: 'hi') }
     Given(:some_filter) { HasPattern.new adapter, id: 'hi' }
     Given(:overridden) { HasPattern.new adapter, id: 'hi', pattern: :overridden }

--- a/spec/lib/mohawk/adapters/uia/table_row_spec.rb
+++ b/spec/lib/mohawk/adapters/uia/table_row_spec.rb
@@ -8,8 +8,8 @@ describe Mohawk::Adapters::UIA::TableRow do
   subject { Mohawk::Adapters::UIA::TableRow.new table, 123 }
 
   def set_expected_cells(h)
-    element.stub(:items).and_return h.values.map {|v| UiaTableCell.new v }
-    table.stub(:headers).and_return h.keys.map(&:to_s)
+    allow(element).to receive(:items).and_return h.values.map {|v| UiaTableCell.new v }
+    allow(table).to receive(:headers).and_return h.keys.map(&:to_s)
   end
 
   context '#all_match?' do

--- a/spec/lib/mohawk_spec.rb
+++ b/spec/lib/mohawk_spec.rb
@@ -131,7 +131,10 @@ describe Mohawk do
   context Mohawk::Adapters do
     Given(:screen) { TestScreen.new }
     Given(:window) { double('window').as_null_object }
-    Given { allow(screen.adapter).to receive(:window).and_return window }
+    Given do
+      allow(screen.adapter).to receive(:window).and_return window
+      allow(window).to receive(:present?)
+    end
 
     context 'window' do
       context '#exist?' do

--- a/spec/lib/mohawk_spec.rb
+++ b/spec/lib/mohawk_spec.rb
@@ -46,12 +46,12 @@ describe Mohawk do
     let(:process) { double 'child process', pid: 123 }
 
     before(:each) do
-      Uia.stub(:find_element).and_return double
-      process.stub(:start).and_return(process)
-      [:exited?, :stop].each &process.method(:stub)
-      ChildProcess.stub(:build).with('./the/app/path.exe').and_return(process)
+      allow(Uia).to receive(:find_element).and_return double
+      allow(process).to receive(:start).and_return(process)
+      [:exited?, :stop].each { |x| allow(process).to receive(x) }
+      allow(ChildProcess).to receive(:build).with('./the/app/path.exe').and_return(process)
 
-      window.stub(:present?).and_return(true)
+      allow(window).to receive(:present?).and_return(true)
 
       Mohawk.app_path = './the/app/path.exe'
     end
@@ -131,7 +131,7 @@ describe Mohawk do
   context Mohawk::Adapters do
     Given(:screen) { TestScreen.new }
     Given(:window) { double('window').as_null_object }
-    Given { screen.adapter.stub(:window).and_return window }
+    Given { allow(screen.adapter).to receive(:window).and_return window }
 
     context 'window' do
       context '#exist?' do

--- a/spec/lib/navigation_spec.rb
+++ b/spec/lib/navigation_spec.rb
@@ -7,7 +7,7 @@ include Mohawk::Navigation
 
 describe Mohawk::Navigation do
   before(:each) do
-    NavigationTestScreen.stub(:new).and_return(screen)
+    allow(NavigationTestScreen).to receive(:new).and_return(screen)
   end
 
   Given(:screen) { double('Mohawk Screen').as_null_object }


### PR DESCRIPTION
Trying to run bundler with `mohawk` was failing for me on Ruby 2.3.3. Upgrading the `json` and `rspec` gems fixed the errors. I also ran into a failing spec, but I'm not sure why it failed; the other specs exactly like it run just fine. Adding in the `allow` for `present?` fixed it. I saw you were doing that elsewhere so it seemed alright to do it here as well.

[JSON issue](https://github.com/flori/json/issues/229)
[RSpec issue](http://stackoverflow.com/a/35893625/139141)
