### PR TITLE
Better error reporting when initializing screens

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,6 +1,5 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '../../', 'lib'))
 
-require 'rspec-expectations'
 require 'childprocess'
 require 'mohawk'
 

--- a/features/support/screens/data_entry_form.rb
+++ b/features/support/screens/data_entry_form.rb
@@ -5,7 +5,7 @@ class DataEntryForm
   table(:people, :id => "personListView")
   button(:add_more, :value => 'Add Many')
 
-  def wait_until_present
+  def wait_until_present(context=nil)
     super
     wait_for_control :id => "personListView"
   end

--- a/lib/mohawk.rb
+++ b/lib/mohawk.rb
@@ -91,8 +91,8 @@ module Mohawk
   #
   # Waits until the window is present
   #
-  def wait_until_present
-    adapter.window.wait_until_present
+  def wait_until_present(context=nil)
+    adapter.window.wait_until_present context
   end
 
   #

--- a/lib/mohawk/accessors.rb
+++ b/lib/mohawk/accessors.rb
@@ -17,7 +17,7 @@ module Mohawk
     end
 
     def required_controls(*controls)
-      define_method(:wait_until_present) do
+      define_method(:wait_until_present) do |context=nil|
         controls.each do |control|
           super()
           begin

--- a/lib/mohawk/adapters/uia/window.rb
+++ b/lib/mohawk/adapters/uia/window.rb
@@ -51,8 +51,8 @@ module Mohawk
           locate_element != nil
         end
 
-        def wait_until_present
-          wait_until(Mohawk.timeout, "Unable to locate window using #{@locator}") { element }
+        def wait_until_present(context=nil)
+          wait_until(Mohawk.timeout, context) { element }
         end
 
         private

--- a/lib/mohawk/adapters/uia/window.rb
+++ b/lib/mohawk/adapters/uia/window.rb
@@ -52,7 +52,7 @@ module Mohawk
         end
 
         def wait_until_present
-          wait_until { element }
+          wait_until(Mohawk.timeout, "Unable to locate window using #{@locator}") { element }
         end
 
         private

--- a/lib/mohawk/adapters/uia_adapter.rb
+++ b/lib/mohawk/adapters/uia_adapter.rb
@@ -6,6 +6,8 @@ module Mohawk
     class UiaAdapter
       include UIA
 
+      attr_reader :locator
+
       def initialize(locator, container=nil)
         @children_only = locator.delete :children_only
         @locator = locator

--- a/lib/mohawk/navigation.rb
+++ b/lib/mohawk/navigation.rb
@@ -6,11 +6,9 @@ module Mohawk
 
     def on(cls, extra = {}, &block)
       screen = cls.new extra
-      screen.wait_until_present
+      screen.wait_until_present "Unable to locate #{cls} using #{screen.adapter.locator}"
       block.call screen if block
       screen
-    rescue Mohawk::Waiter::WaitTimeout => e
-      raise e.class, e.message.sub(/window/, cls.to_s), e.backtrace
     end
   end
 end

--- a/lib/mohawk/navigation.rb
+++ b/lib/mohawk/navigation.rb
@@ -10,7 +10,7 @@ module Mohawk
       block.call screen if block
       screen
     rescue Mohawk::Waiter::WaitTimeout => e
-      raise e.class, "Unable to locate '#{cls}'", e.backtrace
+      raise e.class, e.message.sub(/window/, cls.to_s), e.backtrace
     end
   end
 end

--- a/lib/mohawk/navigation.rb
+++ b/lib/mohawk/navigation.rb
@@ -4,11 +4,13 @@ module Mohawk
   module Navigation
     include PageNavigation
 
-    def on(cls, extra={}, &block)
+    def on(cls, extra = {}, &block)
       screen = cls.new extra
       screen.wait_until_present
       block.call screen if block
       screen
+    rescue Mohawk::Waiter::WaitTimeout => e
+      raise e.class, "Unable to locate '#{cls}'", e.backtrace
     end
   end
 end

--- a/lib/mohawk/navigation.rb
+++ b/lib/mohawk/navigation.rb
@@ -4,7 +4,7 @@ module Mohawk
   module Navigation
     include PageNavigation
 
-    def on(cls, extra = {}, &block)
+    def on(cls, extra={}, &block)
       screen = cls.new extra
       screen.wait_until_present "Unable to locate #{cls} using #{screen.adapter.locator}"
       block.call screen if block

--- a/lib/mohawk/waiter.rb
+++ b/lib/mohawk/waiter.rb
@@ -5,13 +5,13 @@ module Mohawk
     class WaitTimeout < StandardError;
     end
 
-    def wait_until(timeout=Mohawk.timeout, &block)
+    def wait_until(timeout=Mohawk.timeout, context=nil, &block)
       start = Time.now
       until (result = block.call) || (Time.now - start > timeout)
         sleep 0.25
       end
 
-      raise WaitTimeout unless result
+      raise WaitTimeout, context unless result
       result
     end
   end

--- a/spec/lib/mohawk/navigation_spec.rb
+++ b/spec/lib/mohawk/navigation_spec.rb
@@ -1,5 +1,10 @@
 require 'spec_helper'
 
+class NonExistentScreen
+  include Mohawk
+  window(:title => /I don't exist/)
+end
+
 describe Mohawk::Navigation do
   context '#on with extra info' do
     When { start_app }
@@ -21,5 +26,13 @@ describe Mohawk::Navigation do
 
     When(:data_entry_form) { navigate_to(DataEntryForm) }
     Then { expect(data_entry_form).to be_present }
+  end
+
+  context 'name the screen that could not be found' do
+    When { Mohawk.timeout = 1 }
+    Then do
+      screen_class = NonExistentScreen
+      expect { on(screen_class) }.to raise_error Mohawk::Waiter::WaitTimeout, "Unable to locate '#{screen_class}'"
+    end
   end
 end

--- a/spec/lib/mohawk/navigation_spec.rb
+++ b/spec/lib/mohawk/navigation_spec.rb
@@ -1,8 +1,12 @@
 require 'spec_helper'
 
+def non_existent_locator
+  {:title => /I don't exist/}
+end
+
 class NonExistentScreen
   include Mohawk
-  window(:title => /I don't exist/)
+  window non_existent_locator
 end
 
 describe Mohawk::Navigation do
@@ -32,7 +36,7 @@ describe Mohawk::Navigation do
     When { Mohawk.timeout = 1 }
     Then do
       screen_class = NonExistentScreen
-      expect { on(screen_class) }.to raise_error Mohawk::Waiter::WaitTimeout, "Unable to locate '#{screen_class}'"
+      expect { on(screen_class) }.to raise_error Mohawk::Waiter::WaitTimeout, "Unable to locate #{screen_class} using #{non_existent_locator}"
     end
   end
 end

--- a/spec/lib/mohawk/waiter_spec.rb
+++ b/spec/lib/mohawk/waiter_spec.rb
@@ -30,10 +30,22 @@ describe Mohawk::Waiter do
 
   context 'waits in between' do
     When do
-      @fake_responses = [false,  true]
+      @fake_responses = [false, true]
       fake_time 0, 1
     end
 
     Then { expect { waiter.wait_until { do_it } }.not_to raise_error }
   end
+
+  context 'accepts context parameter' do
+    Then { expect { waiter.wait_until(1, 'This is the context') { true } }.not_to raise_error }
+  end
+
+  context 'outputs context on error' do
+    Then do
+      context_string = 'This is the context'
+      expect { waiter.wait_until(1, context_string) { false } }.to raise_error Mohawk::Waiter::WaitTimeout, context_string
+    end
+  end
+
 end


### PR DESCRIPTION
Waiter now mentions the class name when trying to initialize a new screen.

```
class NonExistentScreen
  include Mohawk
  window(:title => /I don't exist/)
end

on(NonExistentScreen)
```

Old error: `Mohawk::Waiter::WaitTimeout: Mohawk::Waiter::WaitTimeout`
~~New error: `Mohawk::Waiter::WaitTimeout: Unable to locate 'NonExistentScreen'`~~
New error: `Mohawk::Waiter::WaitTimeout: Unable to locate NonExistentScreen using {:title=>/I don't exist/}`