### PR TITLE
Update dependencies

### DIFF
--- a/lib/mohawk/adapters/uia/button.rb
+++ b/lib/mohawk/adapters/uia/button.rb
@@ -1,3 +1,5 @@
+require_rel 'control'
+
 module Mohawk
   module Adapters
     module UIA

--- a/lib/mohawk/version.rb
+++ b/lib/mohawk/version.rb
@@ -1,3 +1,3 @@
 module Mohawk
-  VERSION = '0.4.3'
+  VERSION = '0.4.4'
 end

--- a/mohawk.gemspec
+++ b/mohawk.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'uia', '~> 0.5'
-  gem.add_dependency 'require_all'
+  gem.add_dependency 'require_all', '~> 3.0'
   gem.add_dependency 'page_navigation', '>= 0.7'
   gem.add_dependency 'childprocess', '~> 0.5'
 

--- a/spec/lib/mohawk/window_spec.rb
+++ b/spec/lib/mohawk/window_spec.rb
@@ -34,7 +34,10 @@ describe Mohawk::Adapters::UIA::Window do
   end
 
   context '#active?' do
-    Then { not_created_form.active? == false }
+    Then do
+      not_created_form.exist?
+      expect(not_created_form.active?).to eq(false)
+    end
     Then { main_form.active? == true }
 
     context 'inactive --> active' do


### PR DESCRIPTION
Updating the required version for `require_all` to v3 and fixing the instances where the [old behavior](https://github.com/jarmo/require_all/blob/master/CHANGES.md#200) was working. 

Additionally, there was a spec that failed for me locally on Win10 (both in `master` and my branch) where `not_created_form.active?` returned `true` the first time the window was referenced, but `false` the second time. All other specs passed so I added a line that simply uses the window handle to see if the window exists. That seems to get around the issue.