### PR TITLE
Fix running features

### DIFF
--- a/features/step_definitions/table_steps.rb
+++ b/features/step_definitions/table_steps.rb
@@ -4,8 +4,8 @@ When /^we are observing the people table$/ do
 end
 
 Then /^the table row information should look like the following:$/ do |row_items|
-  row_items.map_column!("row") { |r| r.to_i }
-  row_items.map_headers!("text" => :text, "row" => :row)
+  row_items = row_items.map_column("row") { |r| r.to_i }
+  row_items = row_items.map_headers("text" => :text, "row" => :row)
   on(DataEntryForm).people.map(&:to_hash).should eq row_items.hashes
 end
 

--- a/mohawk.gemspec
+++ b/mohawk.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'guard'
   gem.add_development_dependency 'guard-rspec'
   gem.add_development_dependency 'terminal-notifier-guard'
-  gem.add_development_dependency 'json', '~> 2.1.0'
+  gem.add_development_dependency 'json', '~> 2.1'
 end


### PR DESCRIPTION
The `map_column!` and `map_headers!` methods [were removed](https://github.com/cucumber/cucumber-ruby/pull/1590).
Also needed to relax the `json` restriction to allow for newer gem versions, which avoids an error (`wrong number of arguments (given 2, expected 1)`) when we `require 'cucumber'` in the Rakefile.